### PR TITLE
Adjust shape of response data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapauth/node-sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SnapAuth official SDK - server component for passkey and webauthn integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ class SnapAuth {
     }
   }
 
-  attachRegistration = async (token: string, user: UserInfo): Promise<WrappedResponse<RegistrationResponse>> => {
+  attachRegistration = async (token: string, user: UserInfo): Promise<WrappedResponse<CredentialEntity>> => {
     return await this.post('/registration/attach', { token, user })
   }
 
@@ -68,15 +68,16 @@ type WrappedResponse<T> =
   | { ok: false, result: null, errors: SnapAuthError[] }
 
 
-interface RegistrationResponse {
+
+interface CredentialEntity {
+  id: string
+}
+interface UserEntity {
   id: string
 }
 
 interface AuthResponse {
-  user: {
-    id: string
-    handle: string|null
-  }
+  user: UserEntity
 }
 
 interface SnapAuthError {


### PR DESCRIPTION
This a) renames the `RegistrationResponse` to reflect that it's a standard entity (one with only one field right now) and b) removes the `handle` from the `User` in the auth response.