### PR TITLE
Update attach registration to new route name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ class SnapAuth {
   }
 
   attachRegistration = async (token: string, user: UserInfo): Promise<WrappedResponse<CredentialEntity>> => {
-    return await this.post('/registration/attach', { token, user })
+    return await this.post('/credential/create', { token, user })
   }
 
   signIn = async (token: string): Promise<WrappedResponse<AuthResponse>> => {


### PR DESCRIPTION
`registration/attach` has moved to `credential/create` to better align with other Credential APIs. While the old route remains supported, this will be what's used going forward.