### PR TITLE
Update signIn method to verifyAuthToken to match other SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ app.post('/register', async (request, response) => {
 app.post('/signin', async (request, response) => {
   // { token: string }
   const token = request.body.token
-  const auth = await snapAuth.signIn(token)
+  const auth = await snapAuth.verifyAuthToken(token)
   if (auth.ok) {
     signInUserWithId(auth.result.user.id)
   } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,15 @@ class SnapAuth {
     return await this.post('/credential/create', { token, user })
   }
 
-  signIn = async (token: string): Promise<WrappedResponse<AuthResponse>> => {
+  verifyAuthToken = async (token: string): Promise<WrappedResponse<AuthResponse>> => {
     return await this.post('/auth/verify', { token })
+  }
+
+  /**
+   * @deprecated - use verifyAuthToken instead
+   */
+  signIn = async (token: string): Promise<WrappedResponse<AuthResponse>> => {
+    return await this.verifyAuthToken(token)
   }
 
 


### PR DESCRIPTION
This keeps BC for now but deprecates the previous method.